### PR TITLE
Create Bellman_ddp.m

### DIFF
--- a/DDP/Bellman_ddp.m
+++ b/DDP/Bellman_ddp.m
@@ -59,7 +59,7 @@ s_next = s_curr + delta* ( q_curr - R );
 %==========================================================================
 % Compute immediate costs and aggregated one; TO BE ADAPTAED ACCORDING TO
 % YOUR OWN CASE STUDY
-[g1, g2] = immediate_costs( storageToLevel(s_curr).*ones(size(R)), R ) ;
+[g1, g2] = immediate_costs( storageToLevel(s_next), R ) ;
 G = (g1*weights(1) + g2*weights(2))';
 
 %-- Compute cost-to-go given by Bellman function --


### PR DESCRIPTION
Original: [g1, g2] = immediate_costs( storageToLevel(s_curr).*ones(size(R)), R ) ; line 62

Update: [g1, g2] = immediate_costs( storageToLevel(s_next), R ) ; line 62

Comment: The immediate cost for s_curr is calculated in backward moving fashion considering all possible transitions from s_curr to s_next. Therefore, the immediate cost function needs to take as an input s_next.